### PR TITLE
fix(k8s): fix telegraf operator with new mandatory elements. Fix rbac…

### DIFF
--- a/k8s/tool/cleaner/cleaner-clean-completed-jobs.yaml
+++ b/k8s/tool/cleaner/cleaner-clean-completed-jobs.yaml
@@ -50,7 +50,7 @@ data:
       kubectl delete jobs --selector jmeter_mode=master
     fi
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jobs-cleanup

--- a/k8s/tool/telegraf/telegraf-daemonset.yaml
+++ b/k8s/tool/telegraf/telegraf-daemonset.yaml
@@ -60,8 +60,8 @@ spec:
               readOnly: true
             - name: docker-socket
               mountPath: /var/run/docker.sock
-            - name: utmp
-              mountPath: /var/run/utmp
+            # - name: utmp
+            #   mountPath: /var/run/utmp
               readOnly: true
             - name: config
               mountPath: /etc/telegraf
@@ -76,9 +76,9 @@ spec:
         - name: proc
           hostPath:
             path: /proc
-        - name: utmp
-          hostPath:
-            path: /var/run/utmp
+        # - name: utmp
+        #   hostPath:
+        #     path: /var/run/utmp
         - name: config
           configMap:
             name: telegraf

--- a/k8s/tool/telegraf/telegraf-operator.yaml
+++ b/k8s/tool/telegraf/telegraf-operator.yaml
@@ -22,7 +22,7 @@ rules:
     resources: ["secrets"]
     verbs: ["*"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: telegraf-operator
@@ -37,7 +37,7 @@ subjects:
     name: telegraf-operator
     namespace: telegraf-operator
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: telegraf-operator
@@ -50,6 +50,8 @@ webhooks:
     # namespaceSelector:
     #   matchLabels:
     #     controller: telegraf-operator
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
     clientConfig:
       service:
         name: telegraf-operator


### PR DESCRIPTION
… and api v1beta deprecation warning. Commenting utmp mount on the telegraf daemonset to avoid breaking the daemonset on distributions where utmp file is not present or in another path

#7 