### PR TITLE
Update wiremock-deployment.yaml

### DIFF
--- a/k8s/tool/wiremock/wiremock-deployment.yaml
+++ b/k8s/tool/wiremock/wiremock-deployment.yaml
@@ -72,7 +72,7 @@ spec:
     spec:
       containers:
       - name: wiremock
-        image: rbillon59/wiremock-loadtest:monitored
+        image: rbillon59/wiremock-loadtest:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080


### PR DESCRIPTION
Change default wiremock image to take the latest wiremock version with the log4j fix